### PR TITLE
fix: Correct the installation position of the header file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,16 +2,17 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-file(GLOB_RECURSE INCLUDE_FILES "../include/*.h" "../include/settings/*.h")
+file(GLOB SETTING_HEADER "../include/settings/*h")
+file(GLOB COMMON_HEADER "../include/*.h")
+
 file(GLOB_RECURSE SRCS
-    "./settingsSrc/*.h"
-    "./settingsSrc/*.cpp"
     "./*.h"
     "./*.cpp"
 )
 
 add_library(${BIN_NAME} SHARED
-    ${INCLUDE_FILES}
+    ${COMMON_HEADER}
+    ${SETTING_HEADER}
     ${SRCS}
 )
 
@@ -40,5 +41,6 @@ target_link_libraries(${BIN_NAME} PRIVATE
     PkgConfig::NetworkManager
 )
 
-install(FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${BIN_NAME})
+install(FILES ${COMMON_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${BIN_NAME})
+install(FILES ${SETTING_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${BIN_NAME}/settings)
 install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Log: 纠正头文件的安装位置